### PR TITLE
Inherit from client error

### DIFF
--- a/lib/insightly/errors/resource_not_found_error.rb
+++ b/lib/insightly/errors/resource_not_found_error.rb
@@ -1,9 +1,8 @@
+require 'insightly/errors/client_error'
+
 module Insightly
   module Errors
-    class ResourceNotFoundError < StandardError
-      def initialize(response:)
-        @response = response
-      end
+    class ResourceNotFoundError < ClientError
     end
   end
 end

--- a/lib/insightly/version.rb
+++ b/lib/insightly/version.rb
@@ -1,3 +1,3 @@
 module Insightly
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
Adding inheritance here allows you to choose whether to catch just the client error or be more specific with the resource not found error. 
