### PR TITLE
adding stub setting

### DIFF
--- a/lib/insightly2.rb
+++ b/lib/insightly2.rb
@@ -11,6 +11,7 @@ module Insightly2
     # @return [String]
     attr_accessor :api_key
     attr_accessor :logger
+    attr_accessor :stub
   end
 
   module_function

--- a/lib/insightly2/client.rb
+++ b/lib/insightly2/client.rb
@@ -41,10 +41,16 @@ module Insightly2
       raise ArgumentError, "Unsupported method #{method.inspect}. Only :get, :post, :put, :delete are allowed" unless REQUESTS.include?(method)
 
       payload_logger_message = query.empty? ? "with no payload" : "with payload: #{query.inspect}"
-      logger_info_message = "INSIGHTLY starting [#{method.to_s}] request to [#{path.to_s}] #{payload_logger_message}"
+      stubbed_note = Insightly2.stub ? '[STUBBED]' : nil
+      logger_info_message = "#{stubbed_note} INSIGHTLY starting [#{method.to_s}] request to [#{path.to_s}] #{payload_logger_message}"
       LOGGER.info(logger_info_message)
 
       payload = !query.empty? ? JSON.generate(query) : ''
+
+      # Return if stub set to true.
+      return Faraday::Response.new(body: OpenStruct.new, status: "200") if Insightly2.stub
+
+      # The code below runs if Insightly2.stub is not set or set to false.
       response = @connection.run_request(method, "#{URL}#{path}", payload, headers)
 
       case response.status.to_i

--- a/lib/insightly2/version.rb
+++ b/lib/insightly2/version.rb
@@ -1,3 +1,3 @@
 module Insightly2
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end


### PR DESCRIPTION
This allows to stub a request in the initializer.  Instead of actually making it a message will be logged with all the data with `STUBBED` prepended.

Example:

`[STUBBED] INSIGHTLY starting [post] request to [Opportunities] with payload: {}`

This will allow to just set the stub flag and not worry about VCRing request.  If actual testing happens, we should just rely on mocking.